### PR TITLE
feat: Add Raspberry Pi installer and update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,24 @@ jobs:
       - name: Publish RemoteRelay.Server (Linux ARM64)
         run: dotnet publish RemoteRelay.Server/RemoteRelay.Server.csproj --configuration Release /p:PublishProfile=FolderProfile -o ./publish/RemoteRelay-Server-linux-arm64
 
+      - name: Install makeself
+        run: sudo apt-get update && sudo apt-get install -y makeself
+
+      - name: Stage files for makeself
+        run: |
+          mkdir -p makeself_stage/client_files
+          mkdir -p makeself_stage/server_files
+          cp ./publish/RemoteRelay-Client-linux-arm64/RemoteRelay makeself_stage/client_files/
+          cp RemoteRelay/ServerDetails.json makeself_stage/client_files/
+          cp ./publish/RemoteRelay-Server-linux-arm64/RemoteRelay.Server makeself_stage/server_files/
+          cp RemoteRelay.Server/appsettings.json makeself_stage/server_files/
+          cp RemoteRelay.Server/config.json makeself_stage/server_files/
+          cp install.sh makeself_stage/install.sh
+          chmod +x makeself_stage/install.sh
+
+      - name: Run makeself
+        run: makeself ./makeself_stage ./remote-relay-installer.sh "RemoteRelay Installer" ./install.sh
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -94,3 +112,13 @@ jobs:
           asset_path: ./RemoteRelay-Server-linux-arm64.zip
           asset_name: RemoteRelay-Server-linux-arm64.zip
           asset_content_type: application/zip
+
+      - name: Upload RemoteRelay Installer (Raspberry Pi) to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./remote-relay-installer.sh
+          asset_name: remote-relay-installer.sh
+          asset_content_type: application/x-makeself

--- a/README.md
+++ b/README.md
@@ -10,9 +10,37 @@ A platform-agnostic client built in Avalonia, that so far has been tested on Win
 
 ![image](img/ui.png)
 
-The client UI is designed for a pi connected to a touch screen, with the idea that a small touch screen can be installed in a studio for easy access and use. 
+The client UI is designed for a pi connected to a touch screen, with the idea that a small touch screen can be installed in a studio for easy access and use.
+
+## Easy Installation (Recommended)
+For Raspberry Pi users, a self-extracting installer is available that simplifies the setup of the Server, Client, or Both.
+
+1.  **Download the Installer:**
+    Go to the [GitHub Releases page](https://github.com/YOUR_USERNAME/YOUR_REPOSITORY/releases) for this project.
+    Download the `remote-relay-installer.sh` file from the latest release. You can use `wget` for this. For example:
+    ```bash
+    wget https://github.com/YOUR_USERNAME/YOUR_REPOSITORY/releases/latest/download/remote-relay-installer.sh
+    ```
+    (Replace `YOUR_USERNAME/YOUR_REPOSITORY` with the actual path to this repository if you are not the owner reading this).
+
+2.  **Make it Executable:**
+    ```bash
+    chmod +x remote-relay-installer.sh
+    ```
+
+3.  **Run the Installer:**
+    The installer requires superuser privileges to set up services and install files in system directories.
+    ```bash
+    sudo ./remote-relay-installer.sh
+    ```
+    The script will guide you through the installation process:
+    *   You'll be asked if you want to install the **S**erver, **C**lient, or **B**oth.
+    *   If you choose to install the Client (or Both), you'll be prompted for the Server's IP address.
+    *   The installer will automatically copy the necessary files, set permissions, and configure autostart (systemd for the server, desktop autostart for the client).
 
 ## Setup
+For the easiest setup on a Raspberry Pi, please see the 'Easy Installation (Recommended)' section above. The following instructions are for manual setup or for understanding the components.
+
 ### Server
 - Image a Pi with the latest Raspberry Pi OS desktop image (for a server only system, Lite should be fine, but you can run the client and server on the same physical system)
 - Build and Publish RemoteRelay.Server (there are publish tasks currently for linux-arm64)
@@ -22,7 +50,7 @@ The client UI is designed for a pi connected to a touch screen, with the idea th
 	- Set the correct pin numbers (logical addressing is used)
 - chmod +x the server binary
 - Run the server application
-- (Optional) Create a service for the server so it survives reboots
+- (Optional) Create a service for the server so it survives reboots (Handled by the easy installer)
 
 ### Client 
 - Image a Pi with the latest Raspberry Pi OS desktop image 
@@ -31,12 +59,12 @@ The client UI is designed for a pi connected to a touch screen, with the idea th
 - Set the server details in ServerDetails.json
 - chmod +x the client binary
 - Run the client application
-- (Optional) Set the application to launch when the pi boots up
+- (Optional) Set the application to launch when the pi boots up (Handled by the easy installer)
 
 ## To-Do
 - Add support for sending a TCP message to a different service on switch (this could be for triggering a Hot Spare switch in Zetta, a Smart Transfer in Myriad, or for updating digital studio signage)
 - Add support for multiple outputs (Allowing Studio 1 to be routed to Output 1, Studio 2 to Output 2 etc from the same screen)
 - Add support for multiple servers (Because one relay HAT isn't enough!)
 - Add a pin lock so the system can only be used by those who know a code (ie presenters only)
-- Create an automatic install script
-- Create releases with GitHub Actions
+- Automatic installer script (Completed - see Easy Installation section)
+- Automated releases with GitHub Actions (Implemented)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# Define installation directories
+SERVER_INSTALL_DIR="/opt/RemoteRelay.Server"
+CLIENT_INSTALL_DIR="/opt/RemoteRelay.Client"
+SERVER_FILES_DIR="server_files"
+CLIENT_FILES_DIR="client_files"
+
+# Welcome Message
+echo "----------------------------------------------------"
+echo " Welcome to the RemoteRelay Installation Script "
+echo "----------------------------------------------------"
+echo
+
+# Check for root privileges
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script requires superuser privileges. Please run with sudo."
+  exit 1
+fi
+
+# User Choices
+INSTALL_TYPE=""
+SERVER_IP=""
+
+while [[ "$INSTALL_TYPE" != "S" && "$INSTALL_TYPE" != "C" && "$INSTALL_TYPE" != "B" ]]; do
+  read -p "Choose installation type (S for Server, C for Client, B for Both): " INSTALL_TYPE
+  INSTALL_TYPE=$(echo "$INSTALL_TYPE" | tr '[:lower:]' '[:upper:]') # Convert to uppercase
+  if [[ "$INSTALL_TYPE" != "S" && "$INSTALL_TYPE" != "C" && "$INSTALL_TYPE" != "B" ]]; then
+    echo "Invalid input. Please enter S, C, or B."
+  fi
+done
+
+if [[ "$INSTALL_TYPE" == "C" || "$INSTALL_TYPE" == "B" ]]; then
+  DEFAULT_IP="127.0.0.1"
+  if [[ "$INSTALL_TYPE" == "C" ]]; then
+    read -p "Enter the Server's IP address: " SERVER_IP
+  else # Both Server and Client
+    read -p "Enter the Server's IP address (default: $DEFAULT_IP for local server): " USER_INPUT_IP
+    SERVER_IP=${USER_INPUT_IP:-$DEFAULT_IP}
+  fi
+  # Basic IP validation
+  if ! [[ "$SERVER_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid IP address format. Exiting."
+    exit 1
+  fi
+fi
+
+echo # Newline for better readability
+
+# --- Server Installation ---
+install_server() {
+  echo "Starting Server Installation..."
+
+  echo "Creating installation directory: $SERVER_INSTALL_DIR"
+  mkdir -p "$SERVER_INSTALL_DIR"
+  if [ ! -d "$SERVER_FILES_DIR" ]; then
+    echo "Error: Server files directory '$SERVER_FILES_DIR' not found. Make sure it's in the same directory as the installer."
+    exit 1
+  fi
+  echo "Copying server files to $SERVER_INSTALL_DIR..."
+  cp -r "$SERVER_FILES_DIR"/* "$SERVER_INSTALL_DIR/"
+  chmod +x "$SERVER_INSTALL_DIR/RemoteRelay.Server"
+
+  echo "Creating systemd service file: /etc/systemd/system/remote-relay-server.service"
+  cat << EOF > /etc/systemd/system/remote-relay-server.service
+[Unit]
+Description=RemoteRelay Server
+After=network.target
+
+[Service]
+ExecStart=$SERVER_INSTALL_DIR/RemoteRelay.Server
+WorkingDirectory=$SERVER_INSTALL_DIR
+Restart=always
+User=pi
+Environment=DOTNET_ROOT=/usr/share/dotnet # Adjust if .NET is installed elsewhere
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  echo "Reloading systemd daemon..."
+  systemctl daemon-reload
+  echo "Enabling remote-relay-server service..."
+  systemctl enable remote-relay-server.service
+  echo "Starting remote-relay-server service..."
+  systemctl start remote-relay-server.service
+
+  # Check service status
+  if systemctl is-active --quiet remote-relay-server.service; then
+    echo "RemoteRelay Server service is active and running."
+  else
+    echo "Warning: RemoteRelay Server service failed to start. Check logs with 'journalctl -u remote-relay-server.service'"
+  fi
+  echo "Server Installation Complete."
+  echo
+}
+
+# --- Client Installation ---
+install_client() {
+  echo "Starting Client Installation..."
+
+  echo "Creating installation directory: $CLIENT_INSTALL_DIR"
+  mkdir -p "$CLIENT_INSTALL_DIR"
+   if [ ! -d "$CLIENT_FILES_DIR" ]; then
+    echo "Error: Client files directory '$CLIENT_FILES_DIR' not found. Make sure it's in the same directory as the installer."
+    exit 1
+  fi
+  echo "Copying client files to $CLIENT_INSTALL_DIR..."
+  cp -r "$CLIENT_FILES_DIR"/* "$CLIENT_INSTALL_DIR/"
+  chmod +x "$CLIENT_INSTALL_DIR/RemoteRelay"
+
+  SERVER_DETAILS_FILE="$CLIENT_INSTALL_DIR/ServerDetails.json"
+  if [ -f "$SERVER_DETAILS_FILE" ]; then
+    echo "Updating Server IP in $SERVER_DETAILS_FILE to $SERVER_IP..."
+    # Using sed as jq might not be universally available.
+    # This assumes a simple structure like {"Host": "some_ip", ...}
+    # Create a temporary file for sed output
+    TMP_SERVER_DETAILS_FILE=$(mktemp)
+    sed "s/\(\"Host\":\s*\)\"[^\"]*\"/\1\"$SERVER_IP\"/" "$SERVER_DETAILS_FILE" > "$TMP_SERVER_DETAILS_FILE" && mv "$TMP_SERVER_DETAILS_FILE" "$SERVER_DETAILS_FILE"
+    if [ $? -ne 0 ]; then
+        echo "Warning: Failed to update Server IP in $SERVER_DETAILS_FILE using sed."
+        echo "Please ensure $SERVER_DETAILS_FILE contains a line like: \"Host\": \"OLD_IP_ADDRESS\""
+        # Clean up temp file if it still exists
+        [ -f "$TMP_SERVER_DETAILS_FILE" ] && rm "$TMP_SERVER_DETAILS_FILE"
+    fi
+  else
+    echo "Warning: $SERVER_DETAILS_FILE not found. Cannot update Server IP."
+  fi
+
+  # Determine user's home directory for autostart
+  APP_USER="${SUDO_USER:-pi}" # Use SUDO_USER if set, otherwise default to 'pi'
+  USER_HOME=$(eval echo ~$APP_USER)
+  AUTOSART_DIR="$USER_HOME/.config/autostart"
+
+  echo "Creating autostart directory (if it doesn't exist): $AUTOSART_DIR"
+  mkdir -p "$AUTOSART_DIR"
+  # Ensure the APP_USER owns the .config directory and its contents if created by root
+  chown -R $APP_USER:$APP_USER "$USER_HOME/.config"
+
+
+  DESKTOP_FILE="$AUTOSART_DIR/remote-relay-client.desktop"
+  echo "Creating autostart desktop file: $DESKTOP_FILE"
+  cat << EOF > "$DESKTOP_FILE"
+[Desktop Entry]
+Name=RemoteRelay Client
+Exec=$CLIENT_INSTALL_DIR/RemoteRelay
+Path=$CLIENT_INSTALL_DIR/
+Terminal=false
+Type=Application
+X-GNOME-Autostart-enabled=true
+EOF
+  # Set ownership of the desktop file to the user
+  chown $APP_USER:$APP_USER "$DESKTOP_FILE"
+  chmod 644 "$DESKTOP_FILE" # Standard permissions for .desktop files
+
+  echo "Client autostart configured for user '$APP_USER'."
+  echo "Client Installation Complete."
+  echo
+}
+
+# --- Perform Installations Based on User Choice ---
+SUMMARY_MESSAGE="Installation Summary:\n"
+
+if [[ "$INSTALL_TYPE" == "S" || "$INSTALL_TYPE" == "B" ]]; then
+  install_server
+  SUMMARY_MESSAGE+="  - RemoteRelay Server installed to $SERVER_INSTALL_DIR and configured as a service.\n"
+fi
+
+if [[ "$INSTALL_TYPE" == "C" || "$INSTALL_TYPE" == "B" ]]; then
+  install_client
+  SUMMARY_MESSAGE+="  - RemoteRelay Client installed to $CLIENT_INSTALL_DIR, configured with Server IP $SERVER_IP, and set to autostart.\n"
+fi
+
+# Completion Message
+echo "----------------------------------------------------"
+echo " RemoteRelay Installation Finished! "
+echo "----------------------------------------------------"
+echo -e "$SUMMARY_MESSAGE"
+echo "Please check the output above for any warnings or errors."
+echo "If the server was installed, you can check its status with: sudo systemctl status remote-relay-server.service"
+echo "If the client was installed, it will attempt to start on the next login of user '$APP_USER'."
+echo "If both were installed on this machine, ensure the client is configured with IP $SERVER_IP."
+
+exit 0


### PR DESCRIPTION
This commit introduces a self-extracting installer for Raspberry Pi, created using `makeself`.

Key changes:
- Added `install.sh`: A bash script that handles the installation of the server, client, or both components on a Raspberry Pi. It sets up the server as a systemd service and configures the client for GUI autostart. It also prompts for necessary configurations like the server IP.
- Modified `.github/workflows/release.yml`: The release workflow now installs `makeself`, stages the application binaries (client and server for linux-arm64) and configuration files, and then uses `makeself` with `install.sh` to package them into `remote-relay-installer.sh`. This installer is then uploaded as a release asset.
- Updated `README.md`: Added a new "Easy Installation (Recommended)" section detailing how to download and use the new installer. The To-Do list has also been updated.

The installer simplifies deployment on Raspberry Pi devices, providing automatic setup for both server and client components. Manual testing on a target device is recommended after this is merged and a release is generated.