### PR TITLE
feat: Allow configurable active high/low pin logic

### DIFF
--- a/RemoteRelay.Common/RelayConfig.cs
+++ b/RemoteRelay.Common/RelayConfig.cs
@@ -8,4 +8,5 @@ public class RelayConfig
     public string SourceName { get; set; }
     public string OutputName { get; set; }
     public int RelayPin { get; set; }
+    public bool ActiveLow { get; set; } = true;
 }

--- a/RemoteRelay.Server/Relay.cs
+++ b/RemoteRelay.Server/Relay.cs
@@ -1,41 +1,60 @@
 using System.Device.Gpio;
+using RemoteRelay.Common;
 
 namespace RemoteRelay.Server;
 
 public class Source
 {
-   private readonly Dictionary<string, GpioPin> _relayOutputPins;
+   private readonly Dictionary<string, (GpioPin Pin, RelayConfig Config)> _relayOutputPins;
    private GpioPin? _gpiButtonInputPin;
 
    public Source(string sourceName)
    {
-      _relayOutputPins = new Dictionary<string, GpioPin>();
+      _relayOutputPins = new Dictionary<string, (GpioPin Pin, RelayConfig Config)>();
       _sourceName = sourceName;
    }
 
    public string _sourceName { get; set; }
 
-   public void AddOutputPin(ref GpioController controller, string outputName, int pinNumber)
+   public void AddOutputPin(ref GpioController controller, RelayConfig config)
    {
-      var pin = controller.OpenPin(pinNumber, PinMode.Output);
-      _relayOutputPins.Add(outputName, pin);
+      var pin = controller.OpenPin(config.RelayPin, PinMode.Output);
+      _relayOutputPins.Add(config.OutputName, (pin, config));
    }
 
    public void EnableOutput(string output = "")
    {
       if (_relayOutputPins.ContainsKey(output))
-         foreach (var pin in _relayOutputPins)
-            pin.Value.Write(pin.Key == output ? PinValue.Low : PinValue.High);
+      {
+         var targetPinConfig = _relayOutputPins[output].Config;
+         foreach (var entry in _relayOutputPins)
+         {
+            var pin = entry.Value.Pin;
+            var config = entry.Value.Config;
+            if (entry.Key == output)
+            {
+               pin.Write(targetPinConfig.ActiveLow ? PinValue.Low : PinValue.High);
+            }
+            else
+            {
+               pin.Write(config.ActiveLow ? PinValue.High : PinValue.Low);
+            }
+         }
+      }
    }
 
    public void DisableOutput()
    {
-      // write all output pins low
-      foreach (var pin in _relayOutputPins) pin.Value.Write(PinValue.High);
+      foreach (var entry in _relayOutputPins)
+      {
+         var pin = entry.Value.Pin;
+         var config = entry.Value.Config;
+         pin.Write(config.ActiveLow ? PinValue.High : PinValue.Low);
+      }
    }
 
    public string GetCurrentRoute()
    {
-      return _relayOutputPins.FirstOrDefault(x => x.Value.Read() == PinValue.Low).Key;
+      return _relayOutputPins.FirstOrDefault(x => x.Value.Pin.Read() == (x.Value.Config.ActiveLow ? PinValue.Low : PinValue.High)).Key;
    }
 }

--- a/RemoteRelay.Server/SwitcherState.cs
+++ b/RemoteRelay.Server/SwitcherState.cs
@@ -20,10 +20,12 @@ public class SwitcherState
       foreach (var source in settings.Sources)
       {
          var newSource = new Source(source);
-         foreach (var output in
+         foreach (var outputName in
                   settings.Routes.Where(x => x.SourceName == source).Select(x => x.OutputName).Distinct())
-            newSource.AddOutputPin(ref _gpiController, output,
-               settings.Routes.First(x => x.SourceName == source && x.OutputName == output).RelayPin);
+         {
+            var relayConfig = settings.Routes.First(x => x.SourceName == source && x.OutputName == outputName);
+            newSource.AddOutputPin(ref _gpiController, relayConfig);
+         }
          _sources.Add(newSource);
       }
 

--- a/RemoteRelay.Server/config.json
+++ b/RemoteRelay.Server/config.json
@@ -3,17 +3,20 @@
     {
       "SourceName": "Studio 1",
       "OutputName": "Newsroom 1",
-      "RelayPin": 26
+      "RelayPin": 26,
+      "ActiveLow": true
     },
     {
       "SourceName": "Studio 2",
       "OutputName": "Newsroom 1",
-      "RelayPin": 20
+      "RelayPin": 20,
+      "ActiveLow": true
     },
     {
       "SourceName": "Automation",
       "OutputName": "Newsroom 1",
-      "RelayPin": 21
+      "RelayPin": 21,
+      "ActiveLow": true
     }
   ],
   "DefaultSource": "Studio 1",


### PR DESCRIPTION
This change allows individual relay pins to be configured as either active high or active low.

The following changes were made:
- Added an `ActiveLow` boolean property to `RelayConfig.cs` (defaulting to true for backward compatibility).
- Modified `Relay.cs` (`Source` class) to store and use the `ActiveLow` setting from `RelayConfig` when enabling/disabling outputs and determining the current route.
- Updated `SwitcherState.cs` to pass the full `RelayConfig` object (including `ActiveLow`) to the `Source.AddOutputPin` method.
- Updated `config.json` to include the `ActiveLow` property for all configured relays, setting them to `true` (active-low).

This enhancement increases the application's compatibility with a wider range of relay hardware.