### PR TITLE
feat: Display station logo on client

### DIFF
--- a/RemoteRelay.Server/Program.cs
+++ b/RemoteRelay.Server/Program.cs
@@ -25,7 +25,7 @@ public class Program
       app.MapGet("/logo", async (SwitcherState switcherState, ILogger<Program> logger, IWebHostEnvironment env) =>
       {
          var appSettings = switcherState.GetSettings();
-         if (appSettings == null || string.IsNullOrWhiteSpace(appSettings.LogoFile))
+         if (string.IsNullOrWhiteSpace(appSettings.LogoFile))
          {
             logger.LogWarning("Logo file path is not configured.");
             return Results.NotFound("Logo file path is not configured.");

--- a/RemoteRelay.Server/Program.cs
+++ b/RemoteRelay.Server/Program.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using System.IO;
 using RemoteRelay.Common;
 
 namespace RemoteRelay.Server;
@@ -19,6 +21,40 @@ public class Program
 
       app.MapGet("/", () => "This is a SignalR Server for Remote Relay, the hub is hosted at /relay");
       app.MapHub<RelayHub>("/relay");
+
+      app.MapGet("/logo", async (SwitcherState switcherState, ILogger<Program> logger, IWebHostEnvironment env) =>
+      {
+         var appSettings = switcherState.Settings;
+         if (appSettings == null || string.IsNullOrWhiteSpace(appSettings.LogoFile))
+         {
+            logger.LogWarning("Logo file path is not configured.");
+            return Results.NotFound("Logo file path is not configured.");
+         }
+
+         var logoPath = appSettings.LogoFile;
+         if (!Path.IsPathRooted(logoPath))
+         {
+            logoPath = Path.Combine(env.ContentRootPath, logoPath);
+         }
+
+         if (!File.Exists(logoPath))
+         {
+            logger.LogError($"Logo file not found at path: {logoPath}");
+            return Results.NotFound($"Logo file not found at path: {logoPath}");
+         }
+
+         try
+         {
+            var fileBytes = await File.ReadAllBytesAsync(logoPath);
+            logger.LogInformation($"Successfully served logo file: {logoPath}");
+            return Results.File(fileBytes, "image/jpeg"); // Assuming JPEG
+         }
+         catch (Exception ex)
+         {
+            logger.LogError(ex, $"Error reading logo file: {logoPath}");
+            return Results.Problem($"Error reading logo file: {ex.Message}");
+         }
+      });
 
       app.Run();
    }

--- a/RemoteRelay.Server/Program.cs
+++ b/RemoteRelay.Server/Program.cs
@@ -24,7 +24,7 @@ public class Program
 
       app.MapGet("/logo", async (SwitcherState switcherState, ILogger<Program> logger, IWebHostEnvironment env) =>
       {
-         var appSettings = switcherState.Settings;
+         var appSettings = switcherState.GetSettings();
          if (appSettings == null || string.IsNullOrWhiteSpace(appSettings.LogoFile))
          {
             logger.LogWarning("Logo file path is not configured.");

--- a/RemoteRelay/SingleOutput/SingleOutputView.axaml
+++ b/RemoteRelay/SingleOutput/SingleOutputView.axaml
@@ -56,10 +56,12 @@
                         Margin="10" />
 
         <Image Source="{Binding StationLogo}"
-                        Grid.Row="2"
-                        Grid.Column="2"
-                        Margin="10" 
-                        Stretch="UniformToFill"/>
+               Grid.Row="2"
+               Grid.Column="1"
+               Margin="10"
+               Stretch="Uniform"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"/>
 
         <ContentControl Content="{Binding Output}"
                         Grid.Row="2"


### PR DESCRIPTION
Implements the ability to display a station logo on the client, retrieved from the server.

Server-side changes:
- Adds a new GET endpoint `/logo` to `RemoteRelay.Server/Program.cs`.
- This endpoint reads the image path from the `LogoFile` property in `config.json`.
- The path is resolved relative to the content root if not absolute.
- Serves the image as `image/jpeg` with error handling for missing/invalid paths.

Client-side changes:
- Modifies `RemoteRelay/SingleOutput/SingleOutputViewModel.cs` to asynchronously fetch the logo from the server's `/logo` endpoint.
- Removes the old logic of loading the logo from a local file path.
- Updates the `StationLogo` (Bitmap) property upon successful fetch.
- Includes error handling for failed HTTP requests or invalid image data.
- Adjusts `RemoteRelay/SingleOutput/SingleOutputView.axaml` to correctly position the `Image` control (bound to `StationLogo`) in a dedicated grid column between the "Cancel" and "Output" buttons.
- Sets image stretch and alignment properties for proper display.

The `LogoFile` property in `RemoteRelay.Common/AppSettings.cs` (read from `config.json`) is now solely used by the server. The client fetches the logo via the new HTTP endpoint.