### PR TITLE
feat: Implement physical GPIO source button inputs

### DIFF
--- a/RemoteRelay.Common/AppSettings.cs
+++ b/RemoteRelay.Common/AppSettings.cs
@@ -58,23 +58,40 @@ public class InactiveRelaySettings
 [Serializable]
 public struct AppSettings
 {
-   //Sources
-   public List<RelayConfig> Routes { get; set; }
-   public string? DefaultSource { get; set; }
-   public Dictionary<string, PhysicalButtonConfig> PhysicalSourceButtons { get; set; } = new();
+    //Sources
+    public List<RelayConfig> Routes { get; set; }
+    public string? DefaultSource { get; set; }
+    public Dictionary<string, PhysicalButtonConfig> PhysicalSourceButtons { get; set; }
+    // Note: Sources and Outputs are expression-bodied members and don't need initialization here.
+
+    //Communication
+    public int ServerPort { get; set; }
+    public string? TcpMirrorAddress { get; set; }
+    public int? TcpMirrorPort { get; set; }
+
+    //Options
+    public InactiveRelaySettings? InactiveRelay { get; set; }
+    public bool FlashOnSelect { get; set; }
+    public bool ShowIpOnScreen { get; set; }
+    public bool Logging { get; set; }
+    public string LogoFile { get; set; }
+
+    // Parameterless constructor for struct initialization
+    public AppSettings()
+    {
+        PhysicalSourceButtons = new Dictionary<string, PhysicalButtonConfig>();
+        Routes = new List<RelayConfig>();
+        LogoFile = string.Empty;
+        // DefaultSource, TcpMirrorAddress are nullable strings (default to null)
+        // ServerPort, TcpMirrorPort are value types (default to 0 or null)
+        // InactiveRelay is a nullable struct (defaults to null)
+        // Booleans (FlashOnSelect, ShowIpOnScreen, Logging) default to false.
+        // Sources and Outputs are computed properties.
+    }
+
    public IReadOnlyCollection<string> Sources => Routes.Select(x => x.SourceName).Distinct().ToArray();
    public IReadOnlyCollection<string> Outputs => Routes.Select(x => x.OutputName).Distinct().ToArray();
 
 
-   //Communication
-   public int ServerPort { get; set; }
-   public string? TcpMirrorAddress { get; set; }
-   public int? TcpMirrorPort { get; set; }
-
-   //Options
-   public InactiveRelaySettings? InactiveRelay { get; set; }
-   public bool FlashOnSelect { get; set; }
-   public bool ShowIpOnScreen { get; set; }
-   public bool Logging { get; set; }
-   public string LogoFile { get; set; }
+   // Properties moved up to group them, constructor added above.
 }

--- a/RemoteRelay.Common/AppSettings.cs
+++ b/RemoteRelay.Common/AppSettings.cs
@@ -1,6 +1,33 @@
-using System.Device.Gpio; // Assuming PinValue is here
+using System.Device.Gpio;
 
 namespace RemoteRelay.Common;
+
+public class PhysicalButtonConfig
+{
+    public int PinNumber { get; set; }
+
+    private string _triggerState = "Low"; // Default value
+    public string TriggerState
+    {
+        get => _triggerState;
+        private set // Private setter for validation
+        {
+            if (string.Equals(value, "High", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "Low", StringComparison.OrdinalIgnoreCase))
+            {
+                _triggerState = value;
+            }
+            else
+            {
+                throw new ArgumentException("TriggerState must be either \"High\" or \"Low\".");
+            }
+        }
+    }
+
+    public PinValue GetTriggerPinValue() => _triggerState.Equals("Low", StringComparison.OrdinalIgnoreCase) ? PinValue.Low : PinValue.High;
+
+    public PinEventTypes GetTriggerEventType() => _triggerState.Equals("Low", StringComparison.OrdinalIgnoreCase) ? PinEventTypes.Falling : PinEventTypes.Rising;
+}
 
 public class InactiveRelaySettings
 {
@@ -34,7 +61,7 @@ public struct AppSettings
    //Sources
    public List<RelayConfig> Routes { get; set; }
    public string? DefaultSource { get; set; }
-   public Dictionary<string, int> PhysicalSourceButtons { get; set; }
+   public Dictionary<string, PhysicalButtonConfig> PhysicalSourceButtons { get; set; } = new();
    public IReadOnlyCollection<string> Sources => Routes.Select(x => x.SourceName).Distinct().ToArray();
    public IReadOnlyCollection<string> Outputs => Routes.Select(x => x.OutputName).Distinct().ToArray();
 

--- a/RemoteRelay.Server/Program.cs
+++ b/RemoteRelay.Server/Program.cs
@@ -87,9 +87,9 @@ public class Program
 
       var builder = WebApplication.CreateBuilder(args);
       builder.Services.AddSignalR();
-      // Updated SwitcherState registration to include IHubContext<RelayHub>
+      // Updated SwitcherState registration to include IHubContext<RelayHub> and corrected argument order
       builder.Services.AddSingleton<SwitcherState>(sp =>
-          new SwitcherState(sp.GetRequiredService<IHubContext<RelayHub>>(), _settings));
+          new SwitcherState(_settings, sp.GetRequiredService<IHubContext<RelayHub>>()));
       builder.WebHost.ConfigureKestrel(options => { options.ListenAnyIP(_settings.ServerPort); });
 
       var app = builder.Build();

--- a/RemoteRelay.Server/Program.cs
+++ b/RemoteRelay.Server/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using System.IO;
 using RemoteRelay.Common;
 using System.Device.Gpio; // Added for GpioController and PinValue
+using Microsoft.AspNetCore.SignalR; // Added for IHubContext
 
 namespace RemoteRelay.Server;
 
@@ -86,7 +87,9 @@ public class Program
 
       var builder = WebApplication.CreateBuilder(args);
       builder.Services.AddSignalR();
-      builder.Services.AddSingleton<SwitcherState>(_ => new SwitcherState(_settings));
+      // Updated SwitcherState registration to include IHubContext<RelayHub>
+      builder.Services.AddSingleton<SwitcherState>(sp =>
+          new SwitcherState(sp.GetRequiredService<IHubContext<RelayHub>>(), _settings));
       builder.WebHost.ConfigureKestrel(options => { options.ListenAnyIP(_settings.ServerPort); });
 
       var app = builder.Build();

--- a/RemoteRelay.Server/Program.cs
+++ b/RemoteRelay.Server/Program.cs
@@ -87,9 +87,7 @@ public class Program
 
       var builder = WebApplication.CreateBuilder(args);
       builder.Services.AddSignalR();
-      // Updated SwitcherState registration to include IHubContext<RelayHub> and corrected argument order
-      builder.Services.AddSingleton<SwitcherState>(sp =>
-          new SwitcherState(_settings, sp.GetRequiredService<IHubContext<RelayHub>>()));
+      builder.Services.AddSingleton<SwitcherState>(sp => new SwitcherState(_settings, sp.GetRequiredService<Microsoft.AspNetCore.SignalR.IHubContext<RelayHub>>()));
       builder.WebHost.ConfigureKestrel(options => { options.ListenAnyIP(_settings.ServerPort); });
 
       var app = builder.Build();

--- a/RemoteRelay.Server/SwitcherState.cs
+++ b/RemoteRelay.Server/SwitcherState.cs
@@ -1,5 +1,7 @@
 using System.Device.Gpio;
 using RemoteRelay.Common;
+using Microsoft.AspNetCore.SignalR; // Added for IHubContext
+using System.Linq; // Added for LINQ methods
 
 namespace RemoteRelay.Server;
 
@@ -10,10 +12,16 @@ public class SwitcherState
    private readonly List<Source> _sources = new();
    private readonly int outputCount;
    private GpioPin? _inactiveRelayPin;
+   private readonly IHubContext<RelayHub> _hubContext; // Added field
 
-   public SwitcherState(AppSettings settings)
+   // Debouncing for physical buttons
+   private readonly Dictionary<int, DateTime> _lastPinEventTime = new();
+   private static readonly TimeSpan _debounceTime = TimeSpan.FromMilliseconds(200);
+
+   public SwitcherState(AppSettings settings, IHubContext<RelayHub> hubContext) // Added hubContext parameter
    {
       _settings = settings; // Store settings first
+      _hubContext = hubContext; // Store hubContext
 
       if (IsGpiEnvironment())
          _gpiController = new GpioController(PinNumberingScheme.Logical);
@@ -53,6 +61,95 @@ public class SwitcherState
             Console.WriteLine($"Error initializing inactive relay pin {_settings.InactiveRelay.Pin}: {ex.Message}");
             _inactiveRelayPin = null; // Ensure it's null if setup failed
          }
+      }
+
+      // Setup physical buttons
+      if (_settings.PhysicalSourceButtons != null && _gpiController != null)
+      {
+         foreach (var buttonEntry in _settings.PhysicalSourceButtons)
+         {
+            var sourceNameForButton = buttonEntry.Key;
+            var buttonConfig = buttonEntry.Value;
+
+            if (buttonConfig.PinNumber <= 0)
+            {
+               Console.WriteLine($"Skipping physical button for source '{sourceNameForButton}' due to invalid pin number: {buttonConfig.PinNumber}");
+               continue;
+            }
+
+            Console.WriteLine($"Setting up physical button for source '{sourceNameForButton}' on pin {buttonConfig.PinNumber} with trigger state {buttonConfig.TriggerState}");
+            try
+            {
+               _gpiController.OpenPin(buttonConfig.PinNumber, PinMode.InputPullUp);
+               _gpiController.RegisterCallbackForPinValueChangedEvent(
+                  buttonConfig.PinNumber,
+                  buttonConfig.GetTriggerEventType(),
+                  HandlePhysicalButtonChangeEvent);
+               Console.WriteLine($"Successfully registered callback for pin {buttonConfig.PinNumber} for source '{sourceNameForButton}'.");
+            }
+            catch (Exception ex)
+            {
+               Console.WriteLine($"Error setting up physical button for source '{sourceNameForButton}' on pin {buttonConfig.PinNumber}: {ex.Message}");
+            }
+         }
+      }
+   }
+
+   private void HandlePhysicalButtonChangeEvent(object sender, PinValueChangedEventArgs e)
+   {
+      DateTime now = DateTime.UtcNow;
+      if (_lastPinEventTime.TryGetValue(e.PinNumber, out DateTime lastEventTime))
+      {
+         if (now - lastEventTime < _debounceTime)
+         {
+            Console.WriteLine($"Bounce detected on pin {e.PinNumber}. Ignoring event.");
+            return;
+         }
+      }
+      _lastPinEventTime[e.PinNumber] = now;
+
+      Console.WriteLine($"Pin change event: Pin {e.PinNumber}, Type {e.ChangeType} (debounced)");
+
+      var matchedButtonEntry = _settings.PhysicalSourceButtons
+                                     .FirstOrDefault(b => b.Value.PinNumber == e.PinNumber);
+
+      if (matchedButtonEntry.Key == null) // KeyValuePair is a struct, so Key will be null if not found by FirstOrDefault
+      {
+         Console.WriteLine($"Error: No configured button found for pin {e.PinNumber}.");
+         return;
+      }
+
+      var sourceName = matchedButtonEntry.Key;
+      var buttonConfig = matchedButtonEntry.Value;
+
+      if (e.ChangeType == buttonConfig.GetTriggerEventType())
+      {
+         Console.WriteLine($"Physical button pressed for source '{sourceName}' on pin {e.PinNumber}.");
+
+         var route = _settings.Routes.FirstOrDefault(r => r.SourceName == sourceName);
+         if (route == null)
+         {
+            Console.WriteLine($"Error: No route found for source '{sourceName}' triggered by pin {e.PinNumber}.");
+            return;
+         }
+         var targetOutputName = route.OutputName;
+
+         SwitchSource(sourceName, targetOutputName);
+         Console.WriteLine($"Switched to source '{sourceName}' output '{targetOutputName}' due to physical button press on pin {e.PinNumber}.");
+
+         try
+         {
+            _hubContext.Clients.All.SendAsync("SystemState", GetSystemState()).Wait();
+            Console.WriteLine($"Sent SystemState update to clients after physical button press for pin {e.PinNumber}.");
+         }
+         catch (Exception ex)
+         {
+            Console.WriteLine($"Error sending SystemState update after physical button press for pin {e.PinNumber}: {ex.Message}");
+         }
+      }
+      else
+      {
+         Console.WriteLine($"Pin event {e.ChangeType} for pin {e.PinNumber} (source '{sourceName}') was not the configured trigger event type ({buttonConfig.GetTriggerEventType()}).");
       }
    }
 


### PR DESCRIPTION
This commit introduces the ability to use physical buttons connected to Raspberry Pi GPIO pins to trigger source switching.

Key changes:

1.  **Configuration (`config.json` & `AppSettings.cs`):**
    *   A new section `PhysicalSourceButtons` can be added to `config.json`.
    *   Each entry maps a source name (string) to a configuration object
        specifying `PinNumber` (int) and `TriggerState` ("Low" or "High",
        defaults to "Low").
    *   `RemoteRelay.Common/AppSettings.cs` was updated with a
        `PhysicalButtonConfig` class to support this.

2.  **GPIO Input Handling (`SwitcherState.cs`):**
    *   `SwitcherState` now initializes GPIO pins specified in
        `PhysicalSourceButtons` as inputs (specifically `InputPullUp`).
    *   It listens for value changes on these pins.
    *   The `TriggerState` (active low/high) determines whether a falling or
        rising edge triggers the action.
    *   Upon a valid trigger:
        *   The corresponding source is switched live (targeting its first
            configured output route).
        *   An updated system state is broadcast to all connected SignalR
            clients.

3.  **Debouncing (`SwitcherState.cs`):**
    *   A 200ms debounce period is implemented to prevent multiple triggers
        from a single button press due to contact bounce.

4.  **Dependency Injection (`Program.cs`):**
    *   `SwitcherState` now receives `IHubContext<RelayHub>` via DI to
        enable direct client notifications. `Program.cs` was updated
        accordingly.

This feature allows for headless control of the relay system via physical inputs, enhancing its versatility in various hardware setups.